### PR TITLE
[fix]: (6. 임시 저장) 블록 내부의 유닛 데이터 수정 (#33)

### DIFF
--- a/src/data/block_6_Collection.js
+++ b/src/data/block_6_Collection.js
@@ -7,7 +7,7 @@ export const block_6_Collection = {
         {
           name: "git stash",
           description: {
-            text: "Learn what accessibility is and why it is important.",
+            text: "git stash는 변경사항을 임시로 저장할 수 있도록 도와주는 Git 명령어입니다.",
             links: [
               [
                 "Google Devs - Accessibility Fundamentals",

--- a/src/data/block_6_Collection.js
+++ b/src/data/block_6_Collection.js
@@ -9,33 +9,10 @@ export const block_6_Collection = {
           description: {
             text: "git stash는 변경사항을 임시로 저장할 수 있도록 도와주는 Git 명령어입니다.",
             links: [
+              ["Git scm - stash", "https://git-scm.com/docs/git-stash"],
               [
-                "Google Devs - Accessibility Fundamentals",
-                "https://developers.google.com/web/fundamentals/accessibility/",
-              ],
-              [
-                "A11ycasts with Rob Dodson",
-                "https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g",
-              ],
-              [
-                "Udacity - Chromevox Lite",
-                "http://udacity.github.io/ud891/lesson3-semantics-built-in/02-chromevox-lite/",
-              ],
-              [
-                "Dev.to - Why Accessibility Matters",
-                "https://dev.to/lhoffmanwg1/why-accessibility-matters-39nl",
-              ],
-              [
-                "Abilitynet - Why Accessibility Matters",
-                "https://www.abilitynet.org.uk/why-accessibility-matters",
-              ],
-              [
-                "Udacity - Web Accessibility",
-                "https://www.udacity.com/course/web-accessibility--ud891",
-              ],
-              [
-                "Youtube - Headings, Landmarks, and Tabs",
-                "https://www.youtube.com/watch?v=HE2R86EZPMA",
+                "Git tutorial - stash",
+                "https://backlog.com/git-tutorial/kr/reference/stash.html",
               ],
             ],
           },


### PR DESCRIPTION
## 👀 이슈

resolve #33

## 📌 개요

 **`임시 저장`** 블록 내부 유닛들의 설명과 링크 주소가 일치하지 않는 문제가 있었습니다.

## 👩‍💻 작업 사항

- **`git stash`** 유닛의 설명 내용과 링크 주소를  알맞게 수정하였습니다.

## ✅ 참고 사항
- 변경 후 홈페이지
<img width="474" alt="스크린샷 2022-08-23 오후 9 14 52" src="https://user-images.githubusercontent.com/56868605/186155366-57b16202-6b78-445f-aeda-8eda3ef28c18.png">