### PR TITLE
[fix]: git pull 유닛의 설명이 보이지 않는 문제 수정 (#42)

### DIFF
--- a/src/data/block_5_Collection.js
+++ b/src/data/block_5_Collection.js
@@ -20,7 +20,7 @@ export const block_5_Collection = {
         {
           name: "git pull",
           description: {
-            name: "git pull은 원격 저장소에 있는 프로젝트 내용을 로컬 저장소로 가져올 때 사용하는 Git 명령어입니다.",
+            text: "git pull은 원격 저장소에 있는 프로젝트 내용을 로컬 저장소로 가져올 때 사용하는 Git 명령어입니다.",
             links: [
               ["Git scm - pull", "https://git-scm.com/docs/git-pull"],
               [


### PR DESCRIPTION
## 👀 이슈

resolve #42 

## 📌 개요

홈페이지에서 **`git pull`** 의 명령어에 대한 설명이 보이지 않는 문제점이 있었습니다.

## 👩‍💻 작업 사항

**`git pull`** 유닛의 설명을 정의하는 **`block_5_Collection.js`** 파일에서 해당 속성값을<br />
**`text`** 으로 알맞게 수정하였습니다.

## ✅ 참고 사항
- 변경 후 홈페이지
![스크린샷 2022-08-24 오전 11 29 20](https://user-images.githubusercontent.com/56868605/186304380-51b4bbbc-fa97-40f1-98d0-471bbce91a48.png)