### PR TITLE
[fix]: 홈페이지 블록 배치 관련 CSS 변경 (#48)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -94,10 +94,8 @@ export class App extends LitElement {
 
         #collections {
           padding: var(--spacing-xxxl) var(--spacing-xxxl) 0;
-          display: flex;
-          flex-direction: column;
-          align-items: flex-start;
           min-width: min-content;
+          text-align: center;
         }
 
         #footer {
@@ -105,7 +103,7 @@ export class App extends LitElement {
         }
 
         .collection:not(:last-child) {
-          margin: 0 0 var(--spacing-xxl);
+          margin: 0 var(--spacing-l) var(--spacing-xl) 0;
         }
 
         #header,


### PR DESCRIPTION
## 👀 이슈

resolve #48 

## 📌 개요

기존 홈페이지 내 블록의 배치 방법은 한 블록 당 한 줄을 차지하여 블록 개수가<br />많아질수록 불필요한 스크롤링이 필요하였는데, 해당 문제의 개선이 필요하다고<br />생각하였습니다.

## 👩‍💻 작업 사항

**`app.js`** 파일 내 해당 블록의 배치 방법 & 여백 등의 조정을 담당하는<br />**`CSS`** 코드를 수정하여 더욱 많은 내용을 한 눈에 확인이 가능하도록<br />페이지를 **반응형 구조**로 수정하였습니다.

## ✅ 참고 사항
- **변경 후 홈페이지** (GIF파일이기에 화면에 표시되기까지 시간이 다소 소요될 수 있습니다)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/56868605/186693011-dba26c4b-d7fa-4c54-8f3a-e0f5eff62e93.gif)