### PR TITLE
[fix]: 홈페이지 헤더 내 특정 버튼 요소 제거 (#60)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -758,13 +758,6 @@ export class App extends LitElement {
             ></ws-compact-switch>
           </div>
           <ws-button
-            aria-label="Open help"
-            @click="${this.openHelp}"
-            title="Open help"
-          >
-            <ws-icon .template="${helpIconTemplate}"></ws-icon>
-          </ws-button>
-          <ws-button
             aria-label="Share website"
             @click="${this.share}"
             title="Open share menu"


### PR DESCRIPTION
## 👀 이슈

resolve #60 

## 📌 개요

홈페이지 헤더 란에 불필요한 버튼 요소를 제거하고자 하였습니다.

## 👩‍💻 작업 사항

**`app.js`** 파일 내 해당 부분과 관련된 코드를 제거하였습니다.

## ✅ 참고 사항

<img width="145" alt="스크린샷 2022-08-27 오후 6 15 51" src="https://user-images.githubusercontent.com/56868605/187023800-4f372cd0-d864-4844-bedb-4835526013e6.png">